### PR TITLE
Fix up some warnings, and identify calls to OS_PHYSICAL_TO_K0

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ A early decompilation of a game with many waves!
 
 ```
 
-- Copy the Wave Race 64 USA Rom to ``baserom.z64``
+- Copy the Wave Race 64 USA Rom to ``baserom.us.z64``
 
 Assuming that you cloned the repository with --recursive
 

--- a/include/macros.h
+++ b/include/macros.h
@@ -21,7 +21,7 @@
 #ifdef __GNUC__
 #define UNUSED __attribute__((unused))
 #else
-#define UNUSED u32 //default type
+#define UNUSED //Ignore for IDO
 #endif
 
 // Avoid undefined behaviour for non-returning functions

--- a/src/game_1050.c
+++ b/src/game_1050.c
@@ -1,5 +1,6 @@
 #include <ultra64.h>
 #include <PR/gbi.h>
+#include <PR/os.h>
 #include "variables.h"
 #include "functions.h"
 #include "structs.h"
@@ -24,7 +25,7 @@ void func_800468E0(void) {
     s32* sp24;
     */
 
-    gSPSegment(gDisplayListHead++, 0x00, 0x6000000000);
+    gSPSegment(gDisplayListHead++, 0x00, 0);
     gSPSegment(gDisplayListHead++, 0x01, D_80151984);
     gSPSegment(gDisplayListHead++, 0x02, osVirtualToPhysical(&D_8011EDE0));
     gSPSegment(gDisplayListHead++, 0x03, osVirtualToPhysical(D_801518B8));
@@ -40,20 +41,20 @@ void func_800468E0(void) {
          gSPDisplayList(gDisplayListHead++, &D_1000000);
 
     }
-    switch (D_800DAB1C) {                           /* irregular */
+    switch (D_800DAB1C) {
     case 0:
         gDPPipeSync(gDisplayListHead++);
-        gDPSetColorImage(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, D_801542C0[D_80151948] + 0x80000000 );
+        gDPSetColorImage(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, OS_PHYSICAL_TO_K0(D_801542C0[D_80151948]));
         return;
     case 1:
     case 2:
-        gSPSegment(gDisplayListHead++, 0x04, D_801542C0[0xC-10+1] + 0x80000000); //probably fake?
+        gSPSegment(gDisplayListHead++, 0x04, OS_PHYSICAL_TO_K0(D_801542C0[0xC-10+1])); //probably fake?
         gDPPipeSync(gDisplayListHead++);
-        gDPSetColorImage(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, D_801542C0[0xC-10+1] + 0x80000000);
+        gDPSetColorImage(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 320, OS_PHYSICAL_TO_K0(D_801542C0[0xC-10+1]));
         return;
     case 3:
         gDPPipeSync(gDisplayListHead++);
-        gDPSetColorImage(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 640, D_800D45DC[D_800D45D8] + 0x80000000);
+        gDPSetColorImage(gDisplayListHead++, G_IM_FMT_RGBA, G_IM_SIZ_16b, 640, OS_PHYSICAL_TO_K0(D_800D45DC[D_800D45D8]));
         return;
     }
 }
@@ -74,7 +75,7 @@ void func_80046BF4(void) {
 //interesting...
 void func_80046CF8(s32 arg0) {
     first_task = arg0;
-    osSendMesg(&D_80154130, 0x15, 0);
+    osSendMesg(&D_80154130, 0x15, OS_MESG_NOBLOCK);
 }
 
 

--- a/src/game_43A60.c
+++ b/src/game_43A60.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-UNUSED func_80088EA0(void) {
+UNUSED void func_80088EA0(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_43A60/func_80088EA8.s")

--- a/src/game_4F850.c
+++ b/src/game_4F850.c
@@ -14,7 +14,7 @@
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_4F850/func_800963CC.s")
 
-UNUSED func_800964C4(void) {
+UNUSED void func_800964C4(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_4F850/func_800964CC.s")
@@ -37,7 +37,7 @@ UNUSED func_800964C4(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_4F850/func_80098048.s")
 
-UNUSED func_800980C8(void) {
+UNUSED void func_800980C8(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_4F850/func_800980D0.s")

--- a/src/game_52CD0.c
+++ b/src/game_52CD0.c
@@ -40,10 +40,10 @@ void func_80098548(struct_80098548 *arg0, struct_80098548 *arg1) {
 }
 
 
-UNUSED func_80098564(void) {
+UNUSED void func_80098564(void) {
 }
 
-UNUSED func_8009856C(void) {
+UNUSED void func_8009856C(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_80098574.s")
@@ -64,7 +64,7 @@ UNUSED func_8009856C(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_800989E0.s")
 
-UNUSED func_80098A5C(void) {
+UNUSED void func_80098A5C(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_80098A64.s")
@@ -176,7 +176,7 @@ void func_8009B0C8(s32 arg0) {
 }
 
 
-UNUSED func_8009B100(void) {
+UNUSED void func_8009B100(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_8009B108.s")
@@ -221,7 +221,7 @@ UNUSED func_8009B100(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_8009BE40.s")
 
-UNUSED func_8009BEB4(void) {
+UNUSED void func_8009BEB4(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_8009BEBC.s")
@@ -240,7 +240,7 @@ UNUSED func_8009BEB4(void) {
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_8009C00C.s")
 
-UNUSED func_8009C03C(void) {
+UNUSED void func_8009C03C(void) {
 }
 
 #pragma GLOBAL_ASM("asm/nonmatchings/game_52CD0/func_8009C044.s")

--- a/src/game_BD30.c
+++ b/src/game_BD30.c
@@ -1,6 +1,6 @@
 #include "common.h"
 
-UNUSED func_80051530(void) {
+UNUSED void func_80051530(void) {
 }
 
 


### PR DESCRIPTION
Was just looking at the project, and saw some obvious calls to the OS_PHYSICAL_TO_K0 macro so I thought I'd add them in for you. 

Then I noticed a lot of warnings from the IDO compiler due to the UNUSED attribute doing different things between GCC and IDO. In IDO it was defaulting to a u32 type, and in GCC it was using the ignore attribute, but not setting a type which caused it to throw warnings. So to silence those warnings, I just have IDO ignore UNUSED, and then I just set the types manually where it was used. This makes more sense to me because you may run into functions later that have to return a specific type, but are still unused.

Lastly, I fixed the README to use baserom.us.z64 for the filename as I got an error for just using baserom.z64.